### PR TITLE
Support all known reference types

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ typically by piping the output like this:
   <tr>
     <td>References</td>
     <td>References</td>
-    <td>OK: ER</td>
+    <td>OK:<ul>
+    <li>file</li>
+    <li>image</li>
+    <li>ER</li>
+    <li>ERR</li>
+    <li>DER</li>
+    </ul></td>
     <td></td>
     <td></td>
     </tr>
@@ -135,4 +141,3 @@ typically by piping the output like this:
     <td>WIP</td>
     </tr>
   </table>
-

--- a/src/Commands/QaCommands.php
+++ b/src/Commands/QaCommands.php
@@ -118,7 +118,7 @@ class QaCommands extends DrushCommands {
         'data' => $result->data,
       ];
     }
-    $this->output->writeln(Yaml::dump($res, 4, 2));
+    $this->output->writeln(Yaml::dump($res, 5, 2));
   }
 
   /**

--- a/src/Controller/DependenciesReportController.php
+++ b/src/Controller/DependenciesReportController.php
@@ -6,8 +6,6 @@ use Drupal\Core\Controller\ControllerBase;
 
 /**
  * Class DependenciesReportController.
- *
- * @package Drupal\qa\Controller
  */
 class DependenciesReportController extends ControllerBase {
 
@@ -24,6 +22,15 @@ class DependenciesReportController extends ControllerBase {
     ];
   }
 
+  /**
+   * Placeholder controller for "dependencies".
+   *
+   * @param string $qaVariable
+   *   The variable name.
+   *
+   * @return array
+   *   A render array.
+   */
   public function view($qaVariable) {
     return [
       '#type' => 'markup',

--- a/src/Controller/VariablesReportController.php
+++ b/src/Controller/VariablesReportController.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\qa\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 
 /**
  * Class VariablesReportController.
- *
- * @package Drupal\qa\Controller
  */
 class VariablesReportController extends ControllerBase {
 
@@ -24,6 +24,15 @@ class VariablesReportController extends ControllerBase {
     ];
   }
 
+  /**
+   * Placeholder controller for "variables".
+   *
+   * @param string $qaVariable
+   *   The variable name.
+   *
+   * @return array
+   *   A render array.
+   */
   public function view($qaVariable) {
     return [
       '#type' => 'markup',

--- a/src/Controller/WorkflowsReportController.php
+++ b/src/Controller/WorkflowsReportController.php
@@ -68,7 +68,7 @@ class WorkflowsReportController extends ControllerBase {
       'sinkNodes' => 0,
     ];
 
-    /** @var ContentModerationStateInterface $state */
+    /** @var \Drupal\content_moderation\Entity\ContentModerationStateInterface $state */
     foreach ($workflow->getStates() as $state) {
       $id = $state->id();
       $maybeIsland = FALSE;
@@ -127,7 +127,7 @@ class WorkflowsReportController extends ControllerBase {
    * @return array
    *   A table cell array.
    */
-  protected function buildControlCell($workflow, $key) {
+  protected function buildControlCell(array $workflow, $key) {
     $value = $workflow[$key] ?? 0;
     $cell = $value
       ? ['class' => 'qa-results__ko']

--- a/src/System/Module.php
+++ b/src/System/Module.php
@@ -1,33 +1,105 @@
 <?php
-/**
- * @file
- * Module.php
- *
- * @author: Frédéric G. MARAND <fgm@osinet.fr>
- *
- * @copyright (c) 2014 Ouest Systèmes Informatiques (OSInet).
- *
- * @license General Public License version 2 or later
- */
+
+declare(strict_types = 1);
 
 namespace Drupal\qa\System;
 
 use Drupal\Core\Extension\Extension;
 
+/**
+ * Class Module represents information about a module.
+ */
 class Module {
+
+  /**
+   * The name of the module file.
+   *
+   * @var string
+   */
   public $filename;
+
+  /**
+   * Is the module hidden ?
+   *
+   * @var bool
+   */
   public $hidden = FALSE;
+
+  /**
+   * The name of the module.
+   *
+   * @var string
+   */
   public $name;
+
+  /**
+   * Misc information about the module.
+   *
+   * @var array
+   */
   public $info;
+
+  /**
+   * The module extension type: "module" or "profile".
+   *
+   * @var string
+   */
   public $type;
+
+  /**
+   * Is the module enabled (1 for true) ?
+   *
+   * @var int
+   */
   public $status;
+
+  /**
+   * The current database schema version for the module.
+   *
+   * @var string
+   */
+  // phpcs:ignore
   public $schema_version;
+
+  /**
+   * The module weight, used in hooks.
+   *
+   * @var int
+   */
   public $weight = 0;
+
+  /**
+   * The extensions depending on this module.
+   *
+   * @var array
+   */
+  // phpcs:ignore
   public $required_by = [];
+
+  /**
+   * The extensions this module depends on.
+   *
+   * @var array
+   */
   public $requires = [];
+
+  /**
+   * The module sort order, not to be confused with weight.
+   *
+   * @var int
+   */
   public $sort;
 
-  public static function createFromCore(Extension $object) {
+  /**
+   * Create a Module description from a core Extension object.
+   *
+   * @param \Drupal\Core\Extension\Extension $object
+   *   The module information, as provided by core.
+   *
+   * @return \Drupal\qa\System\Module
+   *   The module information, ready to use.
+   */
+  public static function createFromCore(Extension $object): Module {
     $o = new Module();
     $rc = new \ReflectionClass(Extension::class);
 
@@ -43,12 +115,14 @@ class Module {
   }
 
   /**
-   * @return array
+   * Extract information from the modules and their projects.
    *
-   * FIXME very incomplete: still relies on the D7 info structure, missing most
-   * properties on D8.
+   * FIXME very incomplete: relies on the D7 info, missing most D8/9 properties.
+   *
+   * @return array
+   *   A list of modules and theme descriptions.
    */
-  public static function getInfo()  {
+  public static function getInfo() {
     $module_data = system_rebuild_module_data();
     /** @var Module[] $modules */
     $modules = [];
@@ -81,10 +155,22 @@ class Module {
     ];
   }
 
+  /**
+   * Builtin.
+   *
+   * @return string
+   *   The name of the module.
+   */
   public function __toString() {
     return $this->name;
   }
 
+  /**
+   * Obtain a valid project name for any module.
+   *
+   * @return string
+   *   The name of the project associated to that module.
+   */
   public function getProject() {
     if (!isset($this->info['project'])) {
       if (isset($this->info['package']) && $this->info['package'] == 'Core') {
@@ -98,14 +184,27 @@ class Module {
       $project = $this->info['project'];
     }
 
-   return $project;
+    return $project;
   }
 
+  /**
+   * Is the module hidden ?
+   *
+   * @return bool
+   *   Is it ?
+   */
   public function isHidden() {
     return !empty($this->info['hidden']);
   }
 
+  /**
+   * Is the module installed ? (enabled is D7 wording).
+   *
+   * @return bool
+   *   Is it ?
+   */
   public function isEnabled() {
     return !empty($this->status);
   }
+
 }

--- a/src/System/Project.php
+++ b/src/System/Project.php
@@ -1,49 +1,79 @@
 <?php
-/**
- * @file
- * Project.php
- *
- * @author: Frédéric G. MARAND <fgm@osinet.fr>
- *
- * @copyright (c) 2014 Ouest Systèmes Informatiques (OSInet).
- *
- * @license General Public License version 2 or later
- */
+
+declare(strict_types = 1);
 
 namespace Drupal\qa\System;
 
-
+/**
+ * Project represents the weakly defined project structure for an extension.
+ */
 class Project {
   /**
+   * The list of descriptions for the modules in the project.
+   *
    * @var \Drupal\qa\System\Module[]
    */
   public $modules = [];
+
+  /**
+   * The project name.
+   *
+   * @var string
+   */
   public $name;
 
-  public function __construct($name)  {
+  /**
+   * Project constructor.
+   *
+   * @param string $name
+   *   The project name.
+   */
+  public function __construct(string $name) {
     $this->name = $name;
   }
 
+  /**
+   * Add a module description to the project.
+   *
+   * @param \Drupal\qa\System\Module $module
+   *   The description of the module to add.
+   */
   public function addModule(Module $module) {
     $this->modules[$module->name] = $module;
   }
 
+  /**
+   * Sort projects within the module.
+   */
   public function sort() {
     ksort($this->modules);
   }
 
+  /**
+   * Is the project required ?
+   *
+   * @return false
+   *   Is it ?
+   */
   public function isRequired() {
     return FALSE;
   }
 
+  /**
+   * Count the enabled modules in the project.
+   *
+   * @return int
+   *   The count.
+   */
   public function useCount() {
     $count = 0;
 
     foreach ($this->modules as $module) {
-      if ($module->isEnabled())  {
+      if ($module->isEnabled()) {
         $count++;
       }
     }
     return $count;
   }
+
 }


### PR DESCRIPTION
The References.Integrity plugin must check all usual reference types:

- file, image
- DER
- ERR (for Paragraphs)